### PR TITLE
Adding the files needed to allow the devs to mount their local code

### DIFF
--- a/stepup/README.md
+++ b/stepup/README.md
@@ -35,9 +35,9 @@ docker compose exec middleware /var/www/html/bin/console  doctrine:migrations:mi
 
 Then the webauthn db
 ```
-docker compose exec webauthn /var/www/html/bin/console  doctrine:migrations:migrate --env=prod --em=deploy
-
+docker compose exec webauthn /var/www/html/bin/console  doctrine:migrations:migrate --env=prod
 ```
+
 Then you will need to provision the middleware config:
 ```
 sh middleware/middleware-push-config.sh

--- a/stepup/docker-compose.yml
+++ b/stepup/docker-compose.yml
@@ -13,7 +13,6 @@ services:
           - middleware.dev.openconext.local
           - gateway.dev.openconext.local
 
-
   mariadb:
     image: mariadb:10.6
     environment:
@@ -34,8 +33,8 @@ services:
       - ${PWD}/webauthn:/config
     networks:
       openconextdev:
-  
-  ssp: 
+
+  ssp:
     image: ghcr.io/openconext/openconext-devssp/devssp:latest
     networks:
       openconextdev:
@@ -58,7 +57,7 @@ services:
       - ${PWD}/:/config
       - /dev/log:/dev/log
       - ${PWD}/gateway/surfnet_yubikey.yaml:/var/www/html/config/packages/surfnet_yubikey.yaml
-  
+
   ra:
     image: ghcr.io/openconext/stepup-ra/stepup-ra:prod
     networks:
@@ -74,7 +73,7 @@ services:
     volumes:
       - ${PWD}/:/config
       - /dev/log:/dev/log
-  
+
 networks:
   openconextdev:
     driver: bridge

--- a/stepup/docker-compose.yml
+++ b/stepup/docker-compose.yml
@@ -8,6 +8,11 @@ services:
       - 443:443
     networks:
       openconextdev:
+        aliases:
+          - ra.dev.openconext.local
+          - middleware.dev.openconext.local
+          - gateway.dev.openconext.local
+
 
   mariadb:
     image: mariadb:10.6
@@ -41,6 +46,9 @@ services:
     image: ghcr.io/openconext/stepup-middleware/stepup-middleware:prod
     networks:
       openconextdev:
+    volumes:
+      - ${PWD}/:/config
+      - /dev/log:/dev/log
 
   gateway:
     image: ghcr.io/openconext/stepup-gateway/stepup-gateway:prod
@@ -50,7 +58,23 @@ services:
       - ${PWD}/:/config
       - /dev/log:/dev/log
       - ${PWD}/gateway/surfnet_yubikey.yaml:/var/www/html/config/packages/surfnet_yubikey.yaml
+  
+  ra:
+    image: ghcr.io/openconext/stepup-ra/stepup-ra:prod
+    networks:
+      openconextdev:
+    volumes:
+      - ${PWD}/:/config
+      - /dev/log:/dev/log
 
+  selfservice:
+    image: ghcr.io/openconext/stepup-selfservice/stepup-selfservice:prod
+    networks:
+      openconextdev:
+    volumes:
+      - ${PWD}/:/config
+      - /dev/log:/dev/log
+  
 networks:
   openconextdev:
     driver: bridge

--- a/stepup/gateway/docker-compose.override.yml
+++ b/stepup/gateway/docker-compose.override.yml
@@ -1,4 +1,5 @@
 services:
   gateway:
+    image: ghcr.io/openconext/stepup-gateway/stepup-gateway:dev
     volumes:
       - ${CODE_PATH}:/var/www/html

--- a/stepup/gateway/docker-compose.override.yml
+++ b/stepup/gateway/docker-compose.override.yml
@@ -1,0 +1,4 @@
+services:
+  gateway:
+    volumes:
+      - ${CODE_PATH}:/var/www/html

--- a/stepup/middleware/docker-compose.override.yml
+++ b/stepup/middleware/docker-compose.override.yml
@@ -1,4 +1,5 @@
 services:
   middleware:
+    image: ghcr.io/openconext/stepup-middleware/stepup-middleware:dev
     volumes:
       - ${CODE_PATH}:/var/www/html

--- a/stepup/middleware/docker-compose.override.yml
+++ b/stepup/middleware/docker-compose.override.yml
@@ -1,0 +1,4 @@
+services:
+  middleware:
+    volumes:
+      - ${CODE_PATH}:/var/www/html

--- a/stepup/middleware/middleware-institution.json
+++ b/stepup/middleware/middleware-institution.json
@@ -15,6 +15,7 @@
     "allowed_second_factors": [],
     "number_of_tokens_per_identity": 2,
     "self_vet": true,
+    "sso_on_2fa": true,
     "allow_self_asserted_tokens": true
   },
   "institution-b.example.com": {
@@ -24,6 +25,7 @@
     "allowed_second_factors": [],
     "number_of_tokens_per_identity": 2,
     "self_vet": false,
+    "sso_on_2fa": true,
     "allow_self_asserted_tokens": true
   },
   "institution-d.example.com": {

--- a/stepup/ra/docker-compose.override.yml
+++ b/stepup/ra/docker-compose.override.yml
@@ -1,0 +1,5 @@
+services:
+  ra:
+    image: ghcr.io/openconext/stepup-ra/stepup-ra:dev
+    volumes:
+      - ${CODE_PATH}:/var/www/html

--- a/stepup/selfservice/docker-compose.override.yml
+++ b/stepup/selfservice/docker-compose.override.yml
@@ -1,0 +1,5 @@
+services:
+  selfservice:
+    image: ghcr.io/openconext/stepup-selfservice/stepup-selfservice:dev
+    volumes:
+      - ${CODE_PATH}:/var/www/html

--- a/stepup/ssp/docker-compose.override.yml
+++ b/stepup/ssp/docker-compose.override.yml
@@ -1,0 +1,4 @@
+services:
+  ssp:
+    volumes:
+      - ${CODE_PATH}:/var/www/html

--- a/stepup/start-dev-env.sh
+++ b/stepup/start-dev-env.sh
@@ -6,5 +6,5 @@ export CODE_PATH=$2
 
 # Use docker compose to start the environment but with the modified override file
 echo -e "Starting the dev environment with the following command:\n"
-echo -e "docker-compose -f docker-compose.yml -f ./${SERVICE}/docker-compose.override.yml up "${@:3}"\n"
-docker-compose -f docker-compose.yml -f ./${SERVICE}/docker-compose.override.yml up "${@:3}"
+echo -e "docker compose -f docker-compose.yml -f ./${SERVICE}/docker-compose.override.yml up "${@:3}"\n"
+docker compose -f docker-compose.yml -f ./${SERVICE}/docker-compose.override.yml up "${@:3}"

--- a/stepup/start-dev-env.sh
+++ b/stepup/start-dev-env.sh
@@ -5,4 +5,6 @@ export SERVICE=$1
 export CODE_PATH=$2
 
 # Use docker compose to start the environment but with the modified override file
-docker-compose -f docker-compose.yml -f ./${SERVICE}/docker-compose.override.yml up
+echo -e "Starting the dev environment with the following command:\n"
+echo -e "docker-compose -f docker-compose.yml -f ./${SERVICE}/docker-compose.override.yml up "${@:3}"\n"
+docker-compose -f docker-compose.yml -f ./${SERVICE}/docker-compose.override.yml up "${@:3}"

--- a/stepup/start-dev-env.sh
+++ b/stepup/start-dev-env.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Read the command line parameters to configure the dev env
+export SERVICE=$1
+export CODE_PATH=$2
+
+# Use docker compose to start the environment but with the modified override file
+docker-compose -f docker-compose.yml -f ./${SERVICE}/docker-compose.override.yml up

--- a/stepup/webauthn/docker-compose.override.yml
+++ b/stepup/webauthn/docker-compose.override.yml
@@ -1,0 +1,4 @@
+services:
+  webauthn:
+    volumes:
+      - ${CODE_PATH}:/var/www/html

--- a/stepup/webauthn/docker-compose.override.yml
+++ b/stepup/webauthn/docker-compose.override.yml
@@ -1,4 +1,5 @@
 services:
   webauthn:
+    image: ghcr.io/openconext/stepup-webauthn/stepup-webauthn:dev
     volumes:
       - ${CODE_PATH}:/var/www/html


### PR DESCRIPTION
Hi @quartje ! This PR adds the possibility to mount local directories with code into one of the services that the user chooses.

It uses:
* `docker-compose.yml` files that override settings for just the service in question. Each service directory has one of these files. They mount a local volume over `/var/html/www` in the container
* the local directory to mount is chosen from an environment variable because docker compose files have the ability to read env vars and replace them in the file, like a templating system
* a startup script called `start-dev-env.sh` that takes two parameters: the service name and the local directory to mount. Example: `start-dev-env.sh webauthn /home/dan/Stepup-webauthn` (the recommended way would be to use absolute paths).
* the startup script uses these two parameters to read the docker compose override file from the service's directory and replace the code path in that file (by reading it as an env var)

NOTES:
* if you do not like the idea of a startup script (it is a really simple one), we can just instruct the devs on how to run this manually:

    `export CODE_PATH=<path_to_code>`
    `docker-compose -f docker-compose.yml -f <service_directory>/docker-compose.override.yml up`

* I also had another idea where we can have a single docker-compose.override.yml file in the root directory that we can use as a template. And use some sed / bash magic to replace what we need in that file for any service required. But I think it is more prone to errors and also having an override file for each service allows us in the future to do more dev customisation for each service.
