### PR TITLE
Add Stepup API configuration to docker

### DIFF
--- a/stepup/api/docker-compose.override.yml
+++ b/stepup/api/docker-compose.override.yml
@@ -1,0 +1,4 @@
+services:
+  stepupapi:
+    volumes:
+      - ${CODE_PATH}:/var/www/html

--- a/stepup/docker-compose.yml
+++ b/stepup/docker-compose.yml
@@ -51,6 +51,13 @@ services:
       - /dev/log:/dev/log
       - ${PWD}/gateway/surfnet_yubikey.yaml:/var/www/html/config/packages/surfnet_yubikey.yaml
 
+  stepupapi:
+    image: ghcr.io/openconext/stepup-api/stepup-api:prod
+    volumes:
+      - /dev/log:/dev/log
+    networks:
+      openconextdev:
+
 networks:
   openconextdev:
     driver: bridge


### PR DESCRIPTION
Originally the configuration was done in the Stepup API project, but we decided that it would be better to add it to the devconf as well. Mostly because the API uses the Middleware.

This PR is based on the PR created by Dan, to which I added the docker configuration for the Stepup API.