### PR TITLE
Configure Yubico cloud API keys first

### DIFF
--- a/stepup/README.md
+++ b/stepup/README.md
@@ -20,23 +20,28 @@ First, you need to create an entry in your hosts file (/etc/hosts on *nix system
 ```
 127.0.0.1 selfservice.dev.openconext.local webauthn.dev.openconext.local ssp.dev.openconext.local gateway.dev.openconext.local middleware.dev.openconext.local ra.dev.openconext.local demogssp.dev.openconext.local
 ```
-You can then bring up the docker-compose:
 
-```
-docker-compose up -d
+Secondly you need to create the `stepup/gateway/surfnet_yubikey.yaml` filewith your Yubikey API credentials. If you do not have API credentials, you can get them at <https://upgrade.yubico.com/getapikey/>. You require a Yubikey to get an API key.
+
+```yaml
+surfnet_yubikey_api_client:
+  credentials:
+    client_id: 'YOUR_CLIENT_ID'
+    client_secret: 'YOUR_SECRET'
 ```
 
 You should then get the apps initialised
+You can then bring up the containers using docker compose:
 
 Initialise the middelware database:
 ```
 docker compose exec middleware /var/www/html/bin/console  doctrine:migrations:migrate --env=prod --em=deploy
+docker-compose up -d
 ```
 
 Then the webauthn db
 ```
 docker compose exec webauthn /var/www/html/bin/console  doctrine:migrations:migrate --env=prod
-
 ```
 
 Then you will need to provision the middleware config:
@@ -49,23 +54,6 @@ sh middleware-push-institution.sh
 Then, bootstrap the SRAA. For this, you will need to have a Yubikey. Replace Yubikey_ID with the number that is printed on your yubikey. It should be 8 characters. If it is less, prepend it with 0's
 ```
 docker compose exec middleware  /var/www/html/bin/console middleware:bootstrap:identity-with-yubikey urn:collab:person:dev.openconext.local:admin dev.openconext.local "Your Name" Your@email nl_NL Yubikey_ID
-```
-
-You also need a Yubikey API key for your Yubikey to work. You can get it here:
-https://upgrade.yubico.com/getapikey/
-Create the following file "stepup/gateway/surfnet_yubikey.yaml" which should contain:
-
-```
-surfnet_yubikey_api_client:
-  credentials:
-    client_id: 'YOUR_CLIENT_ID'
-    client_secret: 'YOUR_SECRET'
-```
-
-After this, the cache of the gateway needs to be cleared:
-```
-docker compose exec gateway rm -rf  var/cache/prod
-
 ```
 
 Mailcatcher is included. You can view the email by going to http://localhost:1080

--- a/stepup/gateway/surfnet_yubikey.yaml.dist
+++ b/stepup/gateway/surfnet_yubikey.yaml.dist
@@ -1,0 +1,6 @@
+
+surfnet_yubikey_api_client:
+  credentials:
+    # Get your client_id and client_secret from https://upgrade.yubico.com/getapikey/
+    client_id: 'YOUR_CLIENT_ID'
+    client_secret: 'YOUR_SECRET'


### PR DESCRIPTION
This config file is mounted in the container, so it must exist. Because the Symfony cache is empty when the container is first started, it is not neccesary to clear it.