### PR TITLE
Correct the selfService webauthn gssp pubkey

### DIFF
--- a/stepup/middleware/middleware-institution.json
+++ b/stepup/middleware/middleware-institution.json
@@ -24,7 +24,7 @@
     "verify_email": false,
     "allowed_second_factors": [],
     "number_of_tokens_per_identity": 2,
-    "self_vet": false,
+    "self_vet": true,
     "sso_on_2fa": true,
     "allow_self_asserted_tokens": true
   },


### PR DESCRIPTION
It refered to a non existing key. Causing issues when consuming the assertion from the gssp in the Gateway. The dreaded signature validation failure would occur