### PR TITLE
Test RA authentication unhappy flow

### DIFF
--- a/stepup/middleware/middleware-institution.json
+++ b/stepup/middleware/middleware-institution.json
@@ -24,7 +24,7 @@
     "verify_email": false,
     "allowed_second_factors": [],
     "number_of_tokens_per_identity": 2,
-    "self_vet": false,
+    "self_vet": true,
     "sso_on_2fa": true,
     "allow_self_asserted_tokens": true
   },

--- a/stepup/tests/behat/features/bootstrap/RaContext.php
+++ b/stepup/tests/behat/features/bootstrap/RaContext.php
@@ -55,7 +55,7 @@ class RaContext implements Context
     {
         // We visit the RA location url
         $this->minkContext->visit($this->raUrl);
-        $this->iAmLoggedInIntoTheRaPortalAs('admin', 'yubikey');
+        $this->iAmLoggedInIntoTheRaPortalAsWith('admin', 'yubikey');
 
         $this->iVetASpecificSecondFactor(
             $tokenType,
@@ -119,10 +119,10 @@ class RaContext implements Context
     /**
      * @Given /^I am logged in into the ra portal as "([^"]*)" with a "([^"]*)" token$/
      */
-    public function iAmLoggedInIntoTheRaPortalAs($userName, $tokenType)
+    public function iAmLoggedInIntoTheRaPortalAsWith($userName, $tokenType)
     {
         // Login into RA
-        $this->iTryToLoginIntoTheRaPortalAs($userName, $tokenType);
+        $this->iTryToLoginIntoTheRaPortalAsWith($userName, $tokenType);
         // We are now on the RA homepage
         $this->minkContext->assertPageAddress('https://ra.dev.openconext.local');
         $this->iSwitchLocaleTo('English');
@@ -131,9 +131,9 @@ class RaContext implements Context
     }
 
     /**
-     * @Given /^I try to login into the ra portal as "([^"]*)" with a "([^"]*)" token$/
+     * @Given /^I try to login into the ra portal as "([^"]*)"$/
      */
-    public function iTryToLoginIntoTheRaPortalAs($userName, $tokenType)
+    public function iTryToLoginIntoTheRaPortalAs($userName)
     {
         // We visit the RA location url
         $this->minkContext->getSession()->reset();
@@ -141,6 +141,14 @@ class RaContext implements Context
 
         // The admin user logs in and gives a Yubikey second factor
         $this->authContext->authenticateWithIdentityProviderForWithStepup($userName);
+    }
+
+    /**
+     * @Given /^I try to login into the ra portal as "([^"]*)" with a "([^"]*)" token$/
+     */
+    public function iTryToLoginIntoTheRaPortalAsWith($userName, $tokenType)
+    {
+        $this->iTryToLoginIntoTheRaPortalAs($userName);
         switch ($tokenType) {
             case "yubikey":
                 $this->authContext->verifyYuikeySecondFactor();
@@ -704,5 +712,13 @@ class RaContext implements Context
         echo $this->minkContext->getSession()->getCurrentUrl();
         echo $this->minkContext->getSession()->getPage()->getContent();
         die;
+    }
+
+    /**
+     * @Given /^I die$/
+     */
+    public function andIDie()
+    {
+        $this->diePrintingContent();
     }
 }

--- a/stepup/tests/behat/features/ra_login-exception.feature
+++ b/stepup/tests/behat/features/ra_login-exception.feature
@@ -12,3 +12,31 @@ Feature: A RAA can only manage R RA(A)'s on the promotion page
     Then I should see "Error - Access denied"
      And I should see "Authentication was successful, but you are not authorised to use the RA management portal"
 
+  Scenario: User "jane-d4" tries to login with no 2FA token available
+    Given a user "jane-d4" identified by "urn:collab:person:institution-d.example.com:jane-d4" from institution "institution-d.example.com"
+    # The identity does not have a second factor token and can by no means log in to RA
+    And I try to login into the ra portal as "jane-d4"
+    And I press "Submit"
+    Then I should see "Error - Not authorised to sign in"
+    And I should see "Error code"
+    And I should see "11430"
+
+  Scenario: User "joe-a3" tries to login while no acceptable 2FA token is available
+    Given a user "joe-a3" identified by "urn:collab:person:institution-a.example.com:joe-a3" from institution "institution-a.example.com"
+    # The token is not suitable to log in to RA, and the user is not acreditted the RA role.
+    And the user "urn:collab:person:institution-a.example.com:joe-a3" has a vetted "sms" with identifier "+31 (0) 687654321"
+    And I try to login into the ra portal as "joe-a3"
+    And I press "Submit"
+    Then I should see "Error - Not authorised to sign in"
+    And I should see "Error code"
+    And I should see "11430"
+
+  Scenario: User "admin" cancels the second factor authentication
+    Given I try to login into the ra portal as "admin"
+    # Cancel the yubikey second factor authentication
+    Then I press "Cancel"
+    # Pass throug gateway
+    And I press "Submit"
+    Then I should see "Error - Sign in"
+    And I should see "Error code"
+    And I should see "32592"


### PR DESCRIPTION
When logging in to the RA is not possible, we need to be sure the right error page is displayed. That is tested here.

See: https://www.pivotaltracker.com/n/projects/1163646/stories/188230772
See: https://github.com/OpenConext/Stepup-RA/pull/332