### PR TITLE
Add Chrome browser test container

### DIFF
--- a/stepup/docker-compose.yml
+++ b/stepup/docker-compose.yml
@@ -47,6 +47,21 @@ services:
     profiles:
       - "smoketest"
 
+  chrome:
+    image: alpeware/chrome-headless-trunk
+    ports:
+      - 9222:9222
+    environment:
+      - CHROME_OPTS=--ignore-certificate-errors --window-size=1920,1080 --ignore-ssl-errors
+    volumes:
+      - /tmp/chromedata/:/data
+    networks:
+      openconextdev:
+        aliases:
+          - chrome.dev.openconext.local
+    profiles:
+      - "smoketest"
+
   webauthn:
     image: ghcr.io/openconext/stepup-webauthn/stepup-webauthn:${STEPUP_VERSION:-prod}
     ports:


### PR DESCRIPTION
This needs discussion on how this can be added to devconf so the functional tests in GW can run fully automated.

Do we for example need a dedicated image on `ghcr.io/openconext/openconext-basecontainers` so this could be easily pulled on a per project basis?