### PR TITLE
Make core work on arm64

### DIFF
--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -44,36 +44,49 @@ services:
       - 3306:3306
 
   mongo:
-    image: bitnami/mongodb:7.0
+    image: mongo:7
     environment:
-      MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: secret
-      MONGODB_ROOT_PASSWORD: secret
-      MONGODB_REPLICA_SET_NAME: openconext
-      MONGODB_REPLICA_SET_MODE: primary
-      MONGODB_REPLICA_SET_KEY: secretsecret
-      MONGODB_ADVERTISED_HOSTNAME: mongodb
+      MONGO_INITDB_ROOT_USERNAME: ${MONGODB_USERNAME:-root}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGODB_PASSWORD:-secret}
+      MONGO_REPLICA_SET_NAME: ${MONGODB_RS_NAME:-openconext}
     volumes:
       - ./mongo/:/docker-entrypoint-initdb.d/
-      - openconext_mongodb:/bitnami/mongodb
+      - openconext_mongodb:/data/db
     healthcheck:
-      test: ['CMD', 'true']
-      # test:
-      #   [
-      #     "CMD",
-      #     "mongosh",
-      #     "-u",
-      #     "managerw",
-      #     "-p",
-      #     "secret",
-      #     "--eval",
-      #     "db.stats().ok",
-      #     "mongodb://127.0.0.1/manage",
-      #   ]
-      interval: 10s
-      timeout: 10s
-      retries: 3
-      start_period: 20s
+      test: |
+        # After starting, but before being used, we need to initialize the Mongo replication set
+        # we abuse the healthcheck for that, because we need to check the health status anyway
+        mongosh -u $${MONGO_INITDB_ROOT_USERNAME} -p $${MONGO_INITDB_ROOT_PASSWORD} --eval '
+          try {
+            rs.status().ok;
+          }
+          catch ({ name, message }) {
+            print("error:" + name);
+            print("message:" + message);
+            if (name=="MongoServerError" && message.includes("no replset config has been received")) {
+              rs.initiate({
+                _id : "${MONGODB_RS_NAME:-openconext}",
+                members: [ { _id: 0, host: "mongodb:27017" } ]
+              });
+              rs.status().ok;
+            }
+          };
+        '
+      interval: 2s
+      timeout: 3s
+      retries: 5
+    entrypoint: >
+      bash -c '
+          openssl rand -base64 756 > /keyfile \
+          && chown mongodb:mongodb /keyfile \
+          && chmod 400 /keyfile \
+          && exec docker-entrypoint.sh $$@
+      '
+    command: |
+      mongod --bind_ip_all --replSet ${MONGODB_RS_NAME:-openconext} --keyFile /keyfile
+    restart: always
+    ports:
+      - "27017:27017"
     networks:
       coreconextdev:
     hostname: mongodb

--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -110,7 +110,7 @@ services:
     hostname: profile.docker
 
   mujina-idp:
-    image: ghcr.io/openconext/mujina/mujina-idp:8.0.12
+    image: ghcr.io/openconext/mujina/mujina-idp:latest
     volumes:
       - ./:/config
     networks:
@@ -192,7 +192,7 @@ services:
       - "extras"
 
   oidcplaygroundgui:
-    image: ghcr.io/openconext/openconext-oidc-playground/oidc-playground-gui:3.0.1
+    image: ghcr.io/openconext/openconext-oidc-playground/oidc-playground-gui:latest
     networks:
       coreconextdev:
     hostname: oidcplagroundgui.docker
@@ -202,7 +202,7 @@ services:
       - "extras"
 
   oidcplaygroundserver:
-    image: ghcr.io/openconext/openconext-oidc-playground/oidc-playground-server:3.0.1
+    image: ghcr.io/openconext/openconext-oidc-playground/oidc-playground-server:latest
     environment:
       USE_SYSTEM_CA_CERTS: true
     volumes:
@@ -220,7 +220,7 @@ services:
       - "extras"
 
   teamsgui:
-    image: ghcr.io/openconext/openconext-teams-ng/teams-gui:9.3.1
+    image: ghcr.io/openconext/openconext-teams-ng/teams-gui:latest
     volumes:
       - ./:/config
     environment:
@@ -245,7 +245,7 @@ services:
       - "extras"
 
   teamsserver:
-    image: ghcr.io/openconext/openconext-teams-ng/teams-server:9.3.1
+    image: ghcr.io/openconext/openconext-teams-ng/teams-server:latest
     environment:
       USE_SYSTEM_CA_CERTS: true
     volumes:

--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -37,8 +37,9 @@ services:
       - openconext_mariadb:/var/lib/mysql
     healthcheck:
       test: ["CMD", "mysqladmin", "-uroot", "-psecret", "ping", "-h", "localhost"]
-      timeout: 5s
-      retries: 10
+      interval: 10s
+      timeout: 3s
+      retries: 5
     hostname: mariadb.docker
     ports:
       - 3306:3306
@@ -72,7 +73,7 @@ services:
             }
           };
         '
-      interval: 2s
+      interval: 10s
       timeout: 3s
       retries: 5
     entrypoint: >


### PR DESCRIPTION
Most of the containers simply needed to switch to a newer version (that includes arm64 builds in the container images).  Only for Mongo some work work was necessary: the bitnami container don't support arm64 (for bureaucratic reasons), so we switch to the official mongo images.  That required some hackery to initialise the replication set, which the bitnami containers handled internally in the entrypoint scripts.