### PR TITLE
Add chrome container for EB browser tests

### DIFF
--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -467,6 +467,21 @@ services:
     profiles:
       - "sbs"
 
+  chrome:
+    image: alpeware/chrome-headless-trunk
+    ports:
+      - 9222:9222
+    environment:
+      - CHROME_OPTS=--ignore-certificate-errors --window-size=1920,1080 --ignore-ssl-errors
+    volumes:
+      - /tmp/chromedata/:/data
+    networks:
+      coreconextdev:
+        aliases:
+          - chrome.dev.openconext.local
+    profiles:
+      - "test"
+
 networks:
   coreconextdev:
     driver: bridge

--- a/core/start-dev-env.sh
+++ b/core/start-dev-env.sh
@@ -55,16 +55,16 @@ while true; do
 		# Use docker compose to start the environment but with the modified override file(s)
 		echo -e "\nStarting the ${MODE} environment with the following command:\n"
 
-		echo -e "docker compose --profile oidc -f docker-compose.yml "${docker_compose_args[@]}" "${extra_compose_args}" up -d "${@:$number_of_dev_envs}"\n"
-		docker compose --profile oidc -f docker-compose.yml ${docker_compose_args[@]} ${extra_compose_args} up -d "${@:$number_of_dev_envs}"
+		echo -e "docker compose --profile oidc --profile test -f docker-compose.yml "${docker_compose_args[@]}" "${extra_compose_args}" up -d "${@:$number_of_dev_envs}"\n"
+		docker compose --profile oidc --profile test -f docker-compose.yml ${docker_compose_args[@]} ${extra_compose_args} up -d "${@:$number_of_dev_envs}"
 		break
 		;;
 	*)
 		# Use docker compose to start the environment but with the modified override file(s)
 		echo -e "Starting the ${MODE} environment with the following command:\n"
 
-		echo -e "docker compose --profile oidc -f docker-compose.yml "${docker_compose_args[@]}" "${extra_compose_args}" up "${@:$number_of_dev_envs}"\n"
-		docker compose --profile oidc -f docker-compose.yml ${docker_compose_args[@]} ${extra_compose_args} up "${@:$number_of_dev_envs}"
+		echo -e "docker compose --profile oidc --profile test  -f docker-compose.yml "${docker_compose_args[@]}" "${extra_compose_args}" up "${@:$number_of_dev_envs}"\n"
+		docker compose --profile oidc --profile test -f docker-compose.yml ${docker_compose_args[@]} ${extra_compose_args} up "${@:$number_of_dev_envs}"
 		break
 		;;
 	esac


### PR DESCRIPTION
I've added a Chrome container so during Development the Behat browsertests will work locally.

https://github.com/OpenConext/OpenConext-engineblock/pull/1840