### PR TITLE
Fix illegal instruction when starting mongo container on Apple Silicon in Docker desktop

### DIFF
--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -59,6 +59,11 @@ services:
       MONGODB_REPLICA_SET_MODE: primary
       MONGODB_REPLICA_SET_KEY: secretsecret
       MONGODB_ADVERTISED_HOSTNAME: mongodb
+      # Force QEMU emulation instead of Rosetta for x86_64 Apple Silicon Macs.
+      # Rosetta does not support AVX instructions, which this MongoD image requires, causing an
+      # "Illegal instruction" error when starting the container:
+      #     /opt/bitnami/scripts/libos.sh: line 346:    50 Illegal instruction     "$@" > /dev/null 2>&1
+      EXPERIMENTAL_DOCKER_DESKTOP_FORCE_QEMU: 1
     volumes:
       - ./mongo/:/docker-entrypoint-initdb.d/
       - openconext_mongodb:/bitnami/mongodb


### PR DESCRIPTION
Docker Desktop's x86_64 emulation (DOCKER_DEFAULT_PLATFORM=linux/amd64) now uses Rosetta by default. However, Rosetta doesn't support AVX instructions that (the bitnami) mongo 7 image requires, causing "Illegal instruction" errors.

Switch to QEMU emulation using EXPERIMENTAL_DOCKER_DESKTOP_FORCE_QEMU=1, which is slower but does support AVX.