### PR TITLE
Use PHP 8.2 container for stepup

### DIFF
--- a/stepup/azuremfa/docker-compose.override.yml
+++ b/stepup/azuremfa/docker-compose.override.yml
@@ -1,7 +1,7 @@
 ---
 services:
   azuremfa:
-    image: ghcr.io/openconext/openconext-basecontainers/${AZUREMFA_PHP_IMAGE:-php72-apache2-node14-composer2:latest}
+    image: ghcr.io/openconext/openconext-basecontainers/${AZUREMFA_PHP_IMAGE:-php82-apache2-node20-composer2:latest}
     volumes:
       - ${AZUREMFA_CODE_PATH}:/var/www/html
     environment:

--- a/stepup/demogssp/docker-compose.override.yml
+++ b/stepup/demogssp/docker-compose.override.yml
@@ -1,7 +1,7 @@
 ---
 services:
   demogssp:
-    image: ghcr.io/openconext/openconext-basecontainers/${DEMOGSSP_PHP_IMAGE:-php72-apache2-node14-composer2:latest}
+    image: ghcr.io/openconext/openconext-basecontainers/${DEMOGSSP_PHP_IMAGE:-php82-apache2-node20-composer2:latest}
     volumes:
       - ${DEMOGSSP_CODE_PATH}:/var/www/html
     environment:

--- a/stepup/gateway/docker-compose.override.yml
+++ b/stepup/gateway/docker-compose.override.yml
@@ -1,7 +1,7 @@
 ---
 services:
   gateway:
-    image: ghcr.io/openconext/openconext-basecontainers/${GATEWAY_PHP_IMAGE:-php72-apache2-node14-composer2:latest}
+    image: ghcr.io/openconext/openconext-basecontainers/${GATEWAY_PHP_IMAGE:-php82-apache2-node20-composer2:latest}
     volumes:
       - ${GATEWAY_CODE_PATH}:/var/www/html
     environment:

--- a/stepup/middleware/docker-compose.override.yml
+++ b/stepup/middleware/docker-compose.override.yml
@@ -1,7 +1,7 @@
 ---
 services:
   middleware:
-    image: ghcr.io/openconext/openconext-basecontainers/${MIDDLEWARE_PHP_IMAGE:-php72-apache2-node14-composer2:latest}
+    image: ghcr.io/openconext/openconext-basecontainers/${MIDDLEWARE_PHP_IMAGE:-php82-apache2-node20-composer2:latest}
     volumes:
       - ${MIDDLEWARE_CODE_PATH}:/var/www/html
     environment:

--- a/stepup/selfservice/docker-compose.override.yml
+++ b/stepup/selfservice/docker-compose.override.yml
@@ -1,7 +1,7 @@
 ---
 services:
   selfservice:
-    image: ghcr.io/openconext/openconext-basecontainers/${SELFSERVICE_PHP_IMAGE:-php72-apache2-node14-composer2:latest}
+    image: ghcr.io/openconext/openconext-basecontainers/${SELFSERVICE_PHP_IMAGE:-php82-apache2-node20-composer2:latest}
     volumes:
       - ${SELFSERVICE_CODE_PATH}:/var/www/html
     environment:

--- a/stepup/tiqr/docker-compose.override.yml
+++ b/stepup/tiqr/docker-compose.override.yml
@@ -1,7 +1,7 @@
 ---
 services:
   tiqr:
-    image: ghcr.io/openconext/openconext-basecontainers/${TIQR_PHP_IMAGE:-php72-apache2-node14-composer2:latest}
+    image: ghcr.io/openconext/openconext-basecontainers/${TIQR_PHP_IMAGE:-php82-apache2-node20-composer2:latest}
     volumes:
       - ${TIQR_CODE_PATH}:/var/www/html
     environment:

--- a/stepup/webauthn/docker-compose.override.yml
+++ b/stepup/webauthn/docker-compose.override.yml
@@ -1,7 +1,7 @@
 ---
 services:
   webauthn:
-    image: ghcr.io/openconext/openconext-basecontainers/${WEBAUTHN_PHP_IMAGE:-php72-apache2-node14-composer2:latest}
+    image: ghcr.io/openconext/openconext-basecontainers/${WEBAUTHN_PHP_IMAGE:-php82-apache2-node20-composer2:latest}
     volumes:
       - ${WEBAUTHN_CODE_PATH}:/var/www/html
     environment:


### PR DESCRIPTION
Prior to this change, the containers would use the PHP 7.2 containers by default, unless overwritten via .env.

By now, all projects are upgraded to PHP 8.2 on their main branches. So in devconf, 8.2 can become the new default.