### PR TITLE
Improve / fix start/stop scripts

### DIFF
--- a/core/scripts/init.sh
+++ b/core/scripts/init.sh
@@ -115,6 +115,16 @@ echo -e "${ORANGE}Send a PUSH in Manage, which pushes the entities to EngineBloc
 docker compose exec managegui curl -q -s -k -u sysadmin:secret $manageurl/push >/dev/null
 
 printf "\n"
+echo -e "${ORANGE}Restarting managegui to reload Shibboleth SP metadata${NOCOLOR}"
+docker compose restart managegui
+echo -ne "Waiting for managegui to be ready..."
+until docker compose exec managegui curl -s -o /dev/null -w '%{http_code}' http://localhost/ 2>/dev/null | grep -qE '^[^5]'; do
+	echo -n "."
+	sleep 1
+done
+echo -e " ${VINKJE}"
+
+printf "\n"
 echo -e "${BLUE}Please add the following line to your /etc/hosts: ${VINKJE}"
 printf "\n"
 

--- a/core/start-dev-env.sh
+++ b/core/start-dev-env.sh
@@ -34,6 +34,7 @@ docker_compose_options=()    # Array to hold the options for docker compose
 docker_compose_options+=("-f")
 docker_compose_options+=("${SCRIPT_DIR}/docker-compose.yml")
 docker_compose_options+=("--profile" "oidc")
+docker_compose_options+=("--profile" "test")
 
 # Show help hint if no arguments are given
 if [ $# -eq 0 ]; then

--- a/core/stop-dev-env.sh
+++ b/core/stop-dev-env.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-# Use docker compose to start the environment but with the modified override file(s)
+# Use docker compose to stop the environment.
 echo -e "Stopping the dev environment with the following command:\n"
 
-command='docker compose --profile oidc --profile extras --profile invite --profile php --profile dashboard --profile sbs -f docker-compose.yml down'
+command="docker compose --profile oidc --profile test --profile extras --profile invite --profile php --profile dashboard --profile sbs -f docker-compose.yml down --remove-orphans $*"
 echo "$command"
 exec $command

--- a/stepup/stop-dev-env.sh
+++ b/stepup/stop-dev-env.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Use docker compose to start the environment but with the modified override file(s)
-echo -e "Starting the dev environment with the following command:\n"
+# Use docker compose to stop the environment.
+echo -e "Stopping the dev environment with the following command:\n"
 
-echo -e "docker compose --profile smoketest -f docker-compose.yml down\n"
-docker compose --profile smoketest -f docker-compose.yml down
+echo -e "docker compose --profile smoketest -f docker-compose.yml down --remove-orphans $*\n"
+docker compose --profile smoketest -f docker-compose.yml down --remove-orphans $*


### PR DESCRIPTION
## Restart managegui in init.sh to reload Shibboleth SP metadata

After `docker compose down -v`, the Shibboleth metadata cache is gone.
When containers restart, managegui's Shibboleth SP tries to fetch IdP metadata from EngineBlock before init.sh has run migrations, causing a 503 and a 10-minute retry delay that breaks Manage login.

This change ensures a managegui restart after the Manage push so Shibboleth re-fetches the metadata while EngineBlock is fully initialized and ready.

---

## Fix docker start & stop scripts

Prior to this change the `test` profile was not started by default. This is needed to run the chrome behat suite in EB, so we usually need this.

Prior to this change, the `core/stop-dev-env.sh` would not bring down the test profile. This caused orphaned containers, which produced issues related to the docker network not being able to be removed, which prevented a clean startup of the `core` environment.

Prior to this change, the docker compose `-v` flag was not able to be passed to the stop scripts, making it difficult to clean the slate.