### PR TITLE
chore: upgrade Manage to 9.7.2, drop secret from oidc10_rp required

### DIFF
--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -153,7 +153,7 @@ services:
     hostname: mujina.docker
 
   managegui:
-    image: ghcr.io/openconext/openconext-manage/manage-gui:9.6.2
+    image: ghcr.io/openconext/openconext-manage/manage-gui:9.7.2
     environment:
       HTTPD_CSP: ""
       HTTPD_SERVERNAME: "manage.dev.openconext.local"
@@ -175,7 +175,7 @@ services:
         condition: service_healthy
 
   manageserver:
-    image: ghcr.io/openconext/openconext-manage/manage-server:9.6.2
+    image: ghcr.io/openconext/openconext-manage/manage-server:9.7.2
     environment:
       USE_SYSTEM_CA_CERTS: true
     volumes:

--- a/core/manage/application.yml
+++ b/core/manage/application.yml
@@ -50,12 +50,20 @@ push:
     name: PdP
     user: pdp_admin
     password: "secret"
-    enabled: False
+    enabled: false
+  stepup:
+    url: http://localhost:8082/stepup/api
+    user: manage
+    configuration_file: classpath:/stepup_config.json
+    password: secret
+    enabled: false
 
 product:
   name: Manage
   organization: OpenConext DEV
   service_provider_feed_url: http://mds.edugain.org/edugain-v2.xml
+  jira_base_url: https://servicedesk.surf.nl/jira/browse/
+  jira_ticket_prefixes: CXT,SD
   supported_languages: en,nl
   show_oidc_rp: true
 

--- a/core/manage/metadata_configuration/oidc10_rp.schema.json
+++ b/core/manage/metadata_configuration/oidc10_rp.schema.json
@@ -691,7 +691,6 @@
       "required": [
         "name:en",
         "OrganizationName:en",
-        "secret",
         "grants"
       ],
       "additionalProperties": false


### PR DESCRIPTION
sp-dashboard PRs SURFnet/sp-dashboard#1461 and SURFnet/sp-dashboard#1466 fix public OIDC client handling by omitting the secret field entirely instead of sending null (NPE in SecretHook) or "" (fails min-length validation). This required Manage to no longer mandate the secret field for oidc10_rp entities when isPublicClient is true.

The upstream Manage schema was updated post-9.7.2 to remove "secret" from the metaDataFields required array in oidc10_rp.schema.json. Confirmed against manage.test2.surfconext.nl: POST without secret field succeeds for public clients. Verified locally after this upgrade.

Changes:
- docker-compose.yml: bump manage-server and manage-gui 9.6.2 → 9.7.2
- application.yml: add push.stepup.* and product.jira_* required by 9.7.2
- oidc10_rp.schema.json: remove "secret" from required array