### PR TITLE
Add selenium/chrome to core for spd webtests.

### DIFF
--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -449,6 +449,21 @@ services:
     profiles:
       - "sbs"
 
+  test-browser:
+    image: selenium/standalone-chrome:120.0
+    hostname: test-browser
+    ports:
+      - "5900:5900"
+      - "4444:4444"
+    privileged: true
+    shm_size: 2g
+    networks:
+      coreconextdev:
+    profiles:
+      - "dashboard"
+
+
+
 networks:
   coreconextdev:
     driver: bridge


### PR DESCRIPTION
Because restarting the devconf compose environment through spd is finnicky and causes the engine container to restart without taking volume mount config into account, it's easier to make devconf handle the chrome browser.

See https://github.com/SURFnet/sp-dashboard/pull/1480/changes/e24ba0a386c2a0884f7d2344e064a13b962e6ae8